### PR TITLE
Change target selector to get correct ::before

### DIFF
--- a/src/snippets/smol-article-anchors.njk
+++ b/src/snippets/smol-article-anchors.njk
@@ -34,7 +34,7 @@ Finally, we've also included `scroll-margin-top` which adds margin _only_ to an 
   scroll-margin-top: 2em;
 }
 
-.smol-article-anchor:target::before {
+#smol-article-anchor-title:target::before {
   content: "Is it me you're looking for?";
   position: absolute;
   font-size: .9rem;


### PR DESCRIPTION
When I trialed this example, I didn't see the text "Is it me you're looking for?" as the example would suggest, but instead "Aww, you came to see me!" This second string seems to come from the normal "style.css" file & didn't have anything to do with the example. I think to make this work, you'd need to change `.smol-article-anchor:target::before` to `#smol-article-anchor-title:target::before`.

I don't use GitHub much, so please forgive me if the way I've suggested this is abnormal; just tried to suggest the change via their UI. I got a link to your site from Kevin Powell's newsletter.